### PR TITLE
Build fixes for aarch64 / apple silicon

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ libneon_la_SOURCES = src/simd_neon.c
 # With just -mfpu=neon, clang says
 #    /usr/include/clang/3.5.0/include/arm_neon.h:28:2: error: "NEON support not enabled"
 # "-march=armv7-a" makes it shut up. Hopefully this parameter doesn't screw up anything.
-libneon_la_CFLAGS = $(AM_CFLAGS) -mfpu=neon -march=armv7-a
+libneon_la_CFLAGS = $(AM_CFLAGS) -mfpu=neon
 
 libnnedi3_la_LIBADD = libneon.la
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,8 @@ AS_CASE(
         [i?86], [BITS="32" ASFLAGS="$ASFLAGS -DARCH_X86_64=0" X86="true"],
         [x86_64], [BITS="64" ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -DPIC -m amd64" X86="true"],
         [powerpc*], [PPC="true"],
-        [arm*], [ARM="true"] # Maybe doesn't work for all arm systems?
+        [arm*], [ARM="true" ASFLAGS="$ASFLAGS -march=armv7-a"] # Maybe doesn't work for all arm systems?
+        [aarch*], [ARM="true"]
 )
 
 AS_CASE(

--- a/src/cpufeatures.cpp
+++ b/src/cpufeatures.cpp
@@ -64,6 +64,15 @@ void getCPUFeatures(CPUFeatures *cpuFeatures) {
     }
 
 }
+#elif defined(__APPLE__) && defined(NNEDI3_ARM)
+void getCPUFeatures(CPUFeatures *cpuFeatures) {
+    memset(cpuFeatures, 0, sizeof(CPUFeatures));
+    
+    cpuFeatures->can_run_vs = 1;
+    cpuFeatures->half_fp = true;
+    cpuFeatures->neon = true;
+
+}
 #else
 #include <sys/auxv.h>
 


### PR DESCRIPTION
This fixes build issues on aarch64 and the missing `getauxval` function on Mac